### PR TITLE
show more rows on sites page during sites tests

### DIFF
--- a/src/components/Sites/index.jsx
+++ b/src/components/Sites/index.jsx
@@ -157,6 +157,10 @@ export default class SitesList extends Component {
                   page={page}
                   onChangePage={this.handleChangePage}
                   onChangeRowsPerPage={this.handleChangeRowsPerPage}
+                  SelectProps={{
+                    inputProps: { className: 'rows-per-page-input' },
+                    MenuProps: { MenuListProps: { className: 'rows-per-page-menu' } },
+                  }}
                 />
               </TableRow>
             </TableFooter>

--- a/test/e2e/sites.test.js
+++ b/test/e2e/sites.test.js
@@ -88,6 +88,10 @@ test('Should be able to create and delete site', async (t) => { // eslint-disabl
     .contains(`The external site ${siteName} will be created in the region us-seattle.`)
     .click('button.next')
 
+    // Make sure the site will actually show up on the page
+    .click('.rows-per-page-input')
+    .click(Selector('.rows-per-page-menu li').withText('50'))
+
     // check if site was created
     .click(`.site-list .${siteName}`)
     .expect(Selector('.card .header').innerText)


### PR DESCRIPTION
If the newly created test site is pushed to the second page of results, the test fails. This ensures that all the sites will be on one page during the test.