### PR TITLE
silly node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node:10-alpine
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app


### PR DESCRIPTION
node 12 no longer passively accepts objects for response through express. We need to make sure we are casting down to a string explicitly on the /healthcheck endpoint.