### PR TITLE
fix invalid healthcheck crash

### DIFF
--- a/server.js
+++ b/server.js
@@ -149,7 +149,7 @@ app.use('/api', proxy(`${akkerisApi}`, {
 app.get('/healthcheck', (req, res) => {
   const url = decodeURIComponent(req.query.uri);
   if (url) {
-    request({ url }).on('error', e => res.end(e)).pipe(res);
+    request({ url }).on('error', e => res.end(e.message || JSON.stringify(e))).pipe(res);
   } else {
     res.sendStatus(400);
   }


### PR DESCRIPTION
Passing an `Error` object to `res.end()` is crashing the UI. This PR fixes that issue by either passing in `e.message` if defined, or converting the `Error` into a JSON string via `JSON.stringify()`.