### PR TITLE
increase wait time for testing builds, app setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Given that the applicable environment variables have been saved to `config.env`.
 
 1. `cd test`
 2. `docker build -t akkeris-ui-tests .`
-3. `docker run --env-file config.env -n akkeris-ui-tests --rm akkeris-ui-tests`
+3. `docker run --env-file config.env --name akkeris-ui-tests --rm akkeris-ui-tests`
 
 Note - the docker image does not use the `RUN_TESTCAFE` environment variable because it does not contain the full UI.
 

--- a/test/e2e/apps.test.js
+++ b/test/e2e/apps.test.js
@@ -432,7 +432,7 @@ test('Should be able to create view and release builds', async (t) => { // eslin
     .expect(Selector('.release-list tbody').childElementCount)
     .gt(0)
 
-    .wait(5000)
+    .wait(20000)
     .click('.addons-tab')
     .click('.releases-tab')
     .click('.release-list .r0 button.logs')

--- a/test/e2e/appsetups.test.js
+++ b/test/e2e/appsetups.test.js
@@ -100,7 +100,7 @@ test('ensure the app setup works', async (t) => { // eslint-disable-line no-unde
 
     .expect(Selector('.config-environment').exists)
     .ok()
-    .wait(65000)
+    .wait(85000)
 
     .expect(Selector('.config_app').exists)
     .ok();


### PR DESCRIPTION
Tests were timing out due to the quay throttling issue (I think) so this resolves that problem and makes the tests pass again