### PR TITLE
App tab consistency, misc fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7978,8 +7978,7 @@
     "querystringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
-      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
-      "dev": true
+      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
     },
     "raf": {
       "version": "3.4.1",
@@ -8640,8 +8639,7 @@
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-      "dev": true
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resize-observer-polyfill": {
       "version": "1.5.1",
@@ -10597,7 +10595,6 @@
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
       "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
-      "dev": true,
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3172,6 +3172,62 @@
         }
       }
     },
+    "css-loader": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.4.2.tgz",
+      "integrity": "sha512-jYq4zdZT0oS0Iykt+fqnzVLRIeiPWhka+7BqPn+oSIpWJAHak5tmB/WZrJ2a21JhCeFyNnnlroSl8c+MtVndzA==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "cssesc": "^3.0.0",
+        "icss-utils": "^4.1.1",
+        "loader-utils": "^1.2.3",
+        "normalize-path": "^3.0.0",
+        "postcss": "^7.0.23",
+        "postcss-modules-extract-imports": "^2.0.0",
+        "postcss-modules-local-by-default": "^3.0.2",
+        "postcss-modules-scope": "^2.1.1",
+        "postcss-modules-values": "^3.0.0",
+        "postcss-value-parser": "^4.0.2",
+        "schema-utils": "^2.6.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
+          "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
+          "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.4.tgz",
+          "integrity": "sha512-VNjcaUxVnEeun6B2fiiUDjXXBtD4ZSH7pdbfIu1pOFwgptDPLMo/z9jr4sUfsjFVPqDCEin/F7IYlq7/E6yDbQ==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.10.2",
+            "ajv-keywords": "^3.4.1"
+          }
+        }
+      }
+    },
     "css-select": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
@@ -3197,6 +3253,12 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
       "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
+      "dev": true
+    },
+    "cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true
     },
     "csstype": {
@@ -6007,6 +6069,15 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "icss-utils": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-4.1.1.tgz",
+      "integrity": "sha512-4aFq7wvWyMHKgxsH8QQtGpvbASCf+eM3wPRLI6R+MgAnTCZ6STYsRvttLvRWK0Nfif5piF394St3HeJDaljGPA==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.14"
+      }
+    },
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -6085,6 +6156,12 @@
           }
         }
       }
+    },
+    "indexes-of": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
+      "dev": true
     },
     "infer-owner": {
       "version": "1.0.4",
@@ -7816,6 +7893,92 @@
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
+    "postcss": {
+      "version": "7.0.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
+      "integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "source-map": "^0.6.1",
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-modules-extract-imports": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-2.0.0.tgz",
+      "integrity": "sha512-LaYLDNS4SG8Q5WAWqIJgdHPJrDDr/Lv775rMBFUbgjTz6j34lUznACHcdRWroPvXANP2Vj7yNK57vp9eFqzLWQ==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.5"
+      }
+    },
+    "postcss-modules-local-by-default": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-3.0.2.tgz",
+      "integrity": "sha512-jM/V8eqM4oJ/22j0gx4jrp63GSvDH6v86OqyTHHUvk4/k1vceipZsaymiZ5PvocqZOl5SFHiFJqjs3la0wnfIQ==",
+      "dev": true,
+      "requires": {
+        "icss-utils": "^4.1.1",
+        "postcss": "^7.0.16",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.0.0"
+      }
+    },
+    "postcss-modules-scope": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.1.1.tgz",
+      "integrity": "sha512-OXRUPecnHCg8b9xWvldG/jUpRIGPNRka0r4D4j0ESUU2/5IOnpsjfPPmDprM3Ih8CgZ8FXjWqaniK5v4rWt3oQ==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.6",
+        "postcss-selector-parser": "^6.0.0"
+      }
+    },
+    "postcss-modules-values": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-3.0.0.tgz",
+      "integrity": "sha512-1//E5jCBrZ9DmRX+zCtmQtRSV6PV42Ix7Bzj9GbwJceduuf7IqP8MgeTXuRDHOWj2m0VzZD5+roFWDuU8RQjcg==",
+      "dev": true,
+      "requires": {
+        "icss-utils": "^4.0.0",
+        "postcss": "^7.0.6"
+      }
+    },
+    "postcss-selector-parser": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
+      "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
+      "dev": true,
+      "requires": {
+        "cssesc": "^3.0.0",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1"
+      }
+    },
+    "postcss-value-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
+      "integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
+      "dev": true
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -9479,6 +9642,52 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
+    "style-loader": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-1.1.3.tgz",
+      "integrity": "sha512-rlkH7X/22yuwFYK357fMN/BxYOorfnfq0eD7+vqlemSK4wEcejFF1dg4zxP0euBW8NrYx2WZzZ8PPFevr7D+Kw==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.2.3",
+        "schema-utils": "^2.6.4"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
+          "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
+          "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.4.tgz",
+          "integrity": "sha512-VNjcaUxVnEeun6B2fiiUDjXXBtD4ZSH7pdbfIu1pOFwgptDPLMo/z9jr4sUfsjFVPqDCEin/F7IYlq7/E6yDbQ==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.10.2",
+            "ajv-keywords": "^3.4.1"
+          }
+        }
+      }
+    },
     "stylis": {
       "version": "3.5.4",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.4.tgz",
@@ -10488,6 +10697,12 @@
         "is-extendable": "^0.1.1",
         "set-value": "^2.0.1"
       }
+    },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+      "dev": true
     },
     "unique-filename": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "testcafe-browser-provider-selenium": "^0.4.0",
     "testcafe-react-selectors": "0.0.8-alpha3",
     "transfer-webpack-plugin": "0.1.4",
+    "url-parse": "^1.4.7",
     "webpack": "^4.41.2",
     "webpack-cli": "^3.1.2",
     "webpack-dev-middleware": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "6.24.1",
     "babel-preset-stage-2": "6.24.1",
+    "css-loader": "^3.4.2",
     "enzyme": "^3.7.0",
     "eslint": "4.19.1",
     "eslint-config-airbnb": "15.1.0",
@@ -35,6 +36,7 @@
     "eslint-plugin-testcafe": "0.2.1",
     "html-webpack-plugin": "3.2.0",
     "react-test-renderer": "16.6.3",
+    "style-loader": "^1.1.3",
     "uglifyjs-webpack-plugin": "v2.0.1",
     "webpack-dev-server": "^3.8.2"
   },

--- a/src/components/Addons/AttachAddon.jsx
+++ b/src/components/Addons/AttachAddon.jsx
@@ -155,6 +155,7 @@ export default class AttachAddon extends BaseComponent {
 
   submitAddonAttachment = async () => {
     try {
+      this.setState({ loading: true });
       await this.api.attachAddon(this.props.app, this.state.addon.id);
       ReactGA.event({
         category: 'ADDONS',

--- a/src/components/Addons/AttachAddon.jsx
+++ b/src/components/Addons/AttachAddon.jsx
@@ -160,7 +160,10 @@ export default class AttachAddon extends BaseComponent {
         category: 'ADDONS',
         action: 'Attached new addon',
       });
-      this.props.onComplete('Addon Attached', true);
+
+      // Add a pleasing amount of loading instead of flashing the indicator
+      // for a variable amount of time
+      setTimeout(() => this.props.onComplete('Addon Attached', true), 1000);
     } catch (error) {
       if (!this.isCancel(error)) {
         this.setState({
@@ -268,7 +271,7 @@ export default class AttachAddon extends BaseComponent {
             className="next"
             color="primary"
             onClick={stepIndex > 1 ? this.submitAddonAttachment : this.handleNext}
-            disabled={(stepIndex === 0 && this.state.app === '') || stepIndex > 2}
+            disabled={loading || (stepIndex === 0 && this.state.app === '') || stepIndex > 2}
           >
             {stepIndex < 2 ? 'Next' : 'Finish'}
           </Button>

--- a/src/components/Addons/NewAddon.jsx
+++ b/src/components/Addons/NewAddon.jsx
@@ -9,29 +9,27 @@ import ConfirmationModal from '../ConfirmationModal';
 import BaseComponent from '../../BaseComponent';
 
 const style = {
-  stepper: {
+  root: {
     width: '100%',
     maxWidth: 700,
     margin: 'auto',
-    minHeight: 200,
+    height: '266px',
+    paddingBottom: '12px',
+  },
+  stepper: {
+    height: '40px',
   },
   buttons: {
-    div: {
-      marginTop: 24,
-      marginBottom: 12,
-    },
     back: {
       marginRight: 12,
     },
   },
   refresh: {
     div: {
-      marginLeft: 'auto',
-      marginRight: 'auto',
-      width: '40px',
-      height: '50px',
-      paddingTop: '36px',
-      paddingBottom: '36px',
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      flexGrow: 1,
     },
     indicator: {
       display: 'inline-block',
@@ -49,6 +47,15 @@ const style = {
   },
   bold: {
     fontWeight: 'bold',
+  },
+  contentContainer: {
+    margin: '0 32px', height: '200px', display: 'flex', flexDirection: 'column',
+  },
+  stepContainer: {
+    flexGrow: 1, display: 'flex', flexDirection: 'column', justifyContent: 'center',
+  },
+  buttonContainer: {
+    paddingTop: '12px',
   },
 };
 
@@ -166,6 +173,7 @@ export default class NewAddon extends BaseComponent {
   submitAddon = async () => {
     try {
       this.setState({ loading: true });
+
       let { data: addon } = await this.api.createAddon(
         this.props.app,
         this.state.plan.value,
@@ -183,8 +191,8 @@ export default class NewAddon extends BaseComponent {
             category: 'ADDONS',
             action: 'Created new addon',
           });
-          this.props.onComplete('Addon Created');
-          this.setState({ provisioning: false, provisionStatus: 0, provisionMessage: '', loading: false });
+          this.props.onComplete('Addon Created', true);
+          this.setState({ provisioning: false, provisionStatus: 0, provisionMessage: '' });
           return;
         }
         this.setState({ provisioning: true, provisionStatus: Math.atan(0.2 * i) / (Math.PI / 2), provisionMessage: addon.state_description || 'Provisioning...', loading: false });
@@ -278,43 +286,36 @@ export default class NewAddon extends BaseComponent {
   }
 
   renderContent() {
-    const { stepIndex, serviceid, plan } = this.state;
-    const contentStyle = { margin: '0 32px' };
+    const { stepIndex, serviceid, plan, loading } = this.state;
     return (
-      <div style={contentStyle}>
-        <div>{this.renderStep(stepIndex)}</div>
-        <div style={style.buttons.div}>
-          {stepIndex > 0 && (
-            <Button
-              className="back"
-              disabled={stepIndex === 0}
-              onClick={this.handlePrev}
-              style={style.buttons.back}
-            >
-              Back
-            </Button>
-          )}
-          {(stepIndex === 0 || stepIndex === 1) && (
-            <Button
-              variant="contained"
-              className="next"
-              color="primary"
-              onClick={this.handleNext}
-              disabled={stepIndex === 0 ? (serviceid === '') : (isEmpty(plan))}
-            >
-              Next
-            </Button>
-          )}
-          {stepIndex > 1 && (
-            <Button
-              variant="contained"
-              className="next"
-              color="primary"
-              onClick={this.submitAddon}
-            >
-              Finish
-            </Button>
-          )}
+      <div style={style.contentContainer}>
+        {!loading ? (
+          <div style={style.stepContainer}>
+            {this.renderStep(stepIndex)}
+          </div>
+        ) : (
+          <div style={style.refresh.div}>
+            <CircularProgress top={0} size={40} left={0} status="loading" />
+          </div>
+        )}
+        <div style={style.buttonContainer}>
+          <Button
+            className="back"
+            disabled={stepIndex === 0}
+            onClick={this.handlePrev}
+            style={style.buttons.back}
+          >
+            Back
+          </Button>
+          <Button
+            variant="contained"
+            className="next"
+            color="primary"
+            onClick={stepIndex > 1 ? this.submitAddon : this.handleNext}
+            disabled={stepIndex > 2 || (stepIndex === 0 ? (serviceid === '') : (isEmpty(plan)))}
+          >
+            {stepIndex < 2 ? 'Next' : 'Finish'}
+          </Button>
         </div>
       </div>
     );
@@ -322,7 +323,7 @@ export default class NewAddon extends BaseComponent {
 
   render() {
     const {
-      loading, stepIndex, provisioning, provisionMessage, provisionStatus,
+      stepIndex, provisioning, provisionMessage, provisionStatus,
       submitFail, submitMessage, service, plan,
     } = this.state;
     const provisionStyle = { display: 'block', ...style.stepper };
@@ -336,9 +337,9 @@ export default class NewAddon extends BaseComponent {
     const renderCaption = text => <Typography variant="caption" className="step-label-caption">{text}</Typography>;
 
     return (
-      <div>
+      <div style={style.root}>
         <div style={provisionStyle}>
-          <Stepper activeStep={stepIndex}>
+          <Stepper style={style.stepper} activeStep={stepIndex}>
             <Step>
               <StepLabel className="step-0-label" optional={stepIndex > 0 && renderCaption(service.label)}>
                 Select Addon Service
@@ -353,15 +354,7 @@ export default class NewAddon extends BaseComponent {
               <StepLabel>Confirm</StepLabel>
             </Step>
           </Stepper>
-          {!loading ? (
-            <div>
-              {this.renderContent()}
-            </div>
-          ) : (
-            <div style={style.refresh.div}>
-              <CircularProgress top={0} size={40} left={0} style={style.refresh.indicator} status="loading" />
-            </div>
-          )}
+          {this.renderContent()}
           <ConfirmationModal
             open={submitFail}
             onOk={this.handleClose}

--- a/src/components/Addons/NewAddon.jsx
+++ b/src/components/Addons/NewAddon.jsx
@@ -191,7 +191,10 @@ export default class NewAddon extends BaseComponent {
             category: 'ADDONS',
             action: 'Created new addon',
           });
-          this.props.onComplete('Addon Created', true);
+
+          // Add a pleasing amount of loading instead of flashing the indicator
+          // for a variable amount of time
+          setTimeout(() => this.props.onComplete('Addon Created', true), 1000);
           this.setState({ provisioning: false, provisionStatus: 0, provisionMessage: '' });
           return;
         }
@@ -312,7 +315,7 @@ export default class NewAddon extends BaseComponent {
             className="next"
             color="primary"
             onClick={stepIndex > 1 ? this.submitAddon : this.handleNext}
-            disabled={stepIndex > 2 || (stepIndex === 0 ? (serviceid === '') : (isEmpty(plan)))}
+            disabled={loading || stepIndex > 2 || (stepIndex === 0 ? (serviceid === '') : (isEmpty(plan)))}
           >
             {stepIndex < 2 ? 'Next' : 'Finish'}
           </Button>

--- a/src/components/Addons/index.jsx
+++ b/src/components/Addons/index.jsx
@@ -61,12 +61,15 @@ const style = {
     },
   },
   refresh: {
+    tableCell: {
+      padding: '0px',
+    },
     div: {
-      marginLeft: 'auto',
-      marginRight: 'auto',
-      width: '40px',
-      height: '350px',
-      marginTop: '20%',
+      height: '450px',
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'center',
+      alignItems: 'center',
     },
     indicator: {
       display: 'inline-block',
@@ -110,6 +113,7 @@ class Addons extends BaseComponent {
       attachment: null,
       loading: true,
       open: false,
+      collapse: true,
       confirmAddonOpen: false,
       confirmAttachmentOpen: false,
       message: '',
@@ -220,23 +224,22 @@ class Addons extends BaseComponent {
   }
 
   handleNewAddon = () => {
-    this.setState({ new: true });
+    this.setState({ new: true, collapse: false });
   }
 
   handleNewAddonCancel = () => {
-    this.setState({ new: false });
+    this.setState({ collapse: true });
   }
 
   handleAttachAddon = () => {
-    this.setState({ attach: true });
+    this.setState({ attach: true, collapse: false });
   }
 
   handleAttachAddonCancel = () => {
-    this.setState({ attach: false });
+    this.setState({ collapse: true });
   }
 
   handleRemoveAddon = async () => {
-    this.setState({ loading: true });
     try {
       await this.api.deleteAddon(this.props.app.name, this.state.addon.id);
       this.reload('Addon Deleted');
@@ -247,6 +250,7 @@ class Addons extends BaseComponent {
           submitFail: true,
           loading: false,
           new: false,
+          collapse: true,
           confirmAddonOpen: false,
           confirmAttachmentOpen: false,
           attach: false,
@@ -256,7 +260,6 @@ class Addons extends BaseComponent {
   }
 
   handleRemoveAddonAttachment = async () => {
-    this.setState({ loading: true });
     try {
       await this.api.deleteAddonAttachment(
         this.props.app.name,
@@ -274,6 +277,7 @@ class Addons extends BaseComponent {
           submitFail: true,
           loading: false,
           new: false,
+          collapse: true,
           confirmAddonOpen: false,
           confirmAttachmentOpen: false,
           attach: false,
@@ -318,8 +322,10 @@ class Addons extends BaseComponent {
     this.setState({ submitFail: false });
   }
 
-  reload = async (message) => {
-    this.setState({ loading: true });
+  reload = async (message, noLoading) => {
+    if (!noLoading) {
+      this.setState({ loading: true });
+    }
     try {
       const [r1, r2] = await Promise.all([
         this.api.getAppAddons(this.props.app.name),
@@ -330,6 +336,7 @@ class Addons extends BaseComponent {
         addonAttachments: r2.data,
         loading: false,
         new: false,
+        collapse: true,
         message,
         open: true,
         confirmAddonOpen: false,
@@ -465,7 +472,12 @@ class Addons extends BaseComponent {
   render() {
     return (
       <div style={{ overflow: 'visible' }}>
-        <Collapse unmountOnExit mountOnEnter in={this.state.attach || this.state.new}>
+        <Collapse
+          unmountOnExit
+          mountOnEnter
+          onExited={() => this.setState({ new: false, attach: false })}
+          in={!this.state.collapse}
+        >
           <div style={style.collapse.container}>
             <div style={style.collapse.header.container}>
               <Typography style={style.collapse.header.title} variant="overline">{this.state.attach && 'Attach Addon'}{this.state.new && 'New Addon'}</Typography>
@@ -497,7 +509,7 @@ class Addons extends BaseComponent {
               <TableCell style={style.headerCell}>
                 <div style={style.headerActions.container}>
                   <div style={style.headerActions.button}>
-                    {!this.state.attach && !this.state.new && (
+                    {this.state.collapse && (
                       <Tooltip title="Attach Addon" placement="bottom-end">
                         <IconButton
                           className="attach-addon"
@@ -510,7 +522,7 @@ class Addons extends BaseComponent {
                     )}
                   </div>
                   <div style={style.headerActions.button}>
-                    {!this.state.new && !this.state.attach && (
+                    {this.state.collapse && (
                       <Tooltip title="New Addon" placement="bottom-end">
                         <IconButton
                           className="new-addon"
@@ -529,7 +541,7 @@ class Addons extends BaseComponent {
           {this.state.loading ? (
             <TableBody>
               <TableRow>
-                <TableCell colSpan={4}>
+                <TableCell style={style.refresh.tableCell} colSpan={4}>
                   <div style={style.refresh.div}>
                     <CircularProgress top={0} size={40} left={0} style={style.refresh.indicator} status="loading" />
                   </div>

--- a/src/components/Apps/AppOverview.jsx
+++ b/src/components/Apps/AppOverview.jsx
@@ -25,12 +25,11 @@ const style = {
   },
   refresh: {
     div: {
-      marginLeft: 'auto',
-      marginRight: 'auto',
-      width: '40px',
-      height: '40px',
-      marginTop: '10%',
-      paddingBottom: '10%',
+      height: '511px',
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'center',
+      alignItems: 'center',
     },
     indicator: {
       display: 'inline-block',

--- a/src/components/AutoSuggest.jsx
+++ b/src/components/AutoSuggest.jsx
@@ -162,7 +162,7 @@ class AutoSuggest extends BaseComponent {
         <TextField
           onKeyPress={event => catchReturn(event, value)}
           error={errorText ? true : undefined}
-          value={holdSelection ? value : ''}
+          value={holdSelection ? value : undefined}
           {...other}
         />
       </MuiThemeProvider>

--- a/src/components/AutoSuggest.jsx
+++ b/src/components/AutoSuggest.jsx
@@ -43,7 +43,7 @@ class AutoSuggest extends BaseComponent {
     super(props, context);
     this.popperNode = null;
     this.state = {
-      single: '',
+      single: props.initialValue,
       popper: '',
       suggestions: [],
     };
@@ -156,18 +156,18 @@ class AutoSuggest extends BaseComponent {
   }
 
   renderInputComponent(inputProps) { // eslint-disable-line class-methods-use-this
-    const { catchReturn, errorText, value, muiTheme, ...other } = inputProps;
+    const { catchReturn, errorText, value, muiTheme, holdSelection, ...other } = inputProps;
     return (
       <MuiThemeProvider theme={muiTheme}>
         <TextField
           onKeyPress={event => catchReturn(event, value)}
           error={errorText ? true : undefined}
+          value={holdSelection ? value : ''}
           {...other}
         />
       </MuiThemeProvider>
     );
   }
-
 
   render() {
     const { classes, errorText, labelText, className, placeholder } = this.props;
@@ -192,6 +192,7 @@ class AutoSuggest extends BaseComponent {
             label: errorText || labelText || undefined,
             value: this.state.single,
             onChange: this.handleChange('single'),
+            holdSelection: this.props.holdSelection,
           }}
           theme={{
             input: classes.input,
@@ -219,6 +220,8 @@ AutoSuggest.propTypes = {
   handleSearch: PropTypes.func,
   className: PropTypes.string,
   placeholder: PropTypes.string,
+  holdSelection: PropTypes.bool,
+  initialValue: PropTypes.string,
 };
 
 AutoSuggest.defaultProps = {
@@ -227,6 +230,8 @@ AutoSuggest.defaultProps = {
   className: '',
   placeholder: 'Search',
   color: 'white',
+  holdSelction: false,
+  initialValue: '',
 };
 
 export default withStyles(styles)(AutoSuggest);

--- a/src/components/ConfigVars/KeyValue.css
+++ b/src/components/ConfigVars/KeyValue.css
@@ -1,0 +1,34 @@
+.config-span {
+  overflow-x: auto !important;
+  overflow-y: hidden !important;
+  /* Firefox (non-webkit) */
+  scrollbar-width: thin !important;
+}
+
+/* Chrome/Safari (webkit) */
+
+/* Total scrollbar area */
+.config-span::-webkit-scrollbar {
+  height:10px;
+  /* Hide vertical scrollbar */
+  width: 0px;
+}
+
+/* Draggable scrollbar thumb */
+.config-span::-webkit-scrollbar-thumb {
+  height: 6px;
+  border: 3px solid rgba(0, 0, 0, 0);
+  background-clip: padding-box;
+  -webkit-border-radius: 7px;
+  background-color: rgba(0, 0, 0, 0.15);
+  -webkit-box-shadow: inset -1px -1px 0px rgba(0, 0, 0, 0.05), inset 1px 1px 0px rgba(0, 0, 0, 0.05);
+}
+
+.config-span:hover::-webkit-scrollbar-thumb{
+  background-color: rgba(0,0,0,0.3);
+}
+
+/* Remove scrollbar buttons */
+.config-span::-webkit-scrollbar-button {
+  display:none;
+}

--- a/src/components/ConfigVars/KeyValue.jsx
+++ b/src/components/ConfigVars/KeyValue.jsx
@@ -15,6 +15,7 @@ import InfoIcon from '@material-ui/icons/Info';
 import GlobalStyles from '../../config/GlobalStyles';
 import util from '../../services/util';
 import BaseComponent from '../../BaseComponent';
+import './KeyValue.css';
 
 
 const style = {
@@ -75,9 +76,9 @@ export default class KeyValue extends BaseComponent {
   renderAddConfigVar() {
     return (
       <TableRow hover className="new-config-var" key="new-config-var" style={style.tableRow}>
-        <TableCell padding="none" style={{ ...style.configVar, ...style.tableCell}}>
+        <TableCell padding="none" style={{ ...style.configVar, ...style.tableCell }}>
           <TextField
-            style={{maxWidth:'300px'}}
+            style={{ maxWidth: '300px' }}
             className="new-config-var-key"
             onChange={event => this.setState({ key: event.target.value })}
             InputProps={{ style: style.configVar.textField }}
@@ -93,7 +94,7 @@ export default class KeyValue extends BaseComponent {
         </TableCell>
         <TableCell style={{ ...style.configVar, ...style.tableCell }}>
           <TextField
-            style={{maxWidth:'450px'}}
+            style={{ maxWidth: '450px' }}
             className="new-config-var-value"
             onChange={event => this.setState({ value: event.target.value })}
             InputProps={{ style: style.configVar.textField }}
@@ -120,8 +121,8 @@ export default class KeyValue extends BaseComponent {
     );
   }
 
-  renderConfigVarNotes() { 
-    return ( 
+  renderConfigVarNotes() {
+    return (
       <Tooltip title={this.props.notes.description} placement="top-start">
         <IconButton>
           <InfoIcon style={GlobalStyles.Subtle} />
@@ -168,14 +169,14 @@ export default class KeyValue extends BaseComponent {
     if (this.props.deleted) {
       configVarStyle.textDecoration = 'line-through';
     }
-    const hasNotes = this.props.notes && this.props.notes.description && this.props.notes.description !== "";
+    const hasNotes = this.props.notes && this.props.notes.description && this.props.notes.description !== '';
     return (
       <TableRow className={this.props.configkey} key={this.props.configkey} style={style.tableRow}> { /* eslint-disable-line */ }
         <TableCell padding="none" style={{ ...style.configVar, ...style.tableCell }}>
-          <span style={{...GlobalStyles.CommitLink, ...GlobalStyles.CommitLinkPre, ...configVarStyle, 'maxWidth':'300px'}}>{this.props.configkey}</span> { /* eslint-disable-line */ }
+          <span className="config-span" style={{...GlobalStyles.CommitLink, ...GlobalStyles.CommitLinkPre, ...configVarStyle, 'maxWidth':'300px'}}>{this.props.configkey}</span> { /* eslint-disable-line */ }
         </TableCell>
         <TableCell style={{ ...style.configVar, ...style.tableCell }}>
-          <span style={{...GlobalStyles.CommitLink, ...GlobalStyles.CommitLinkPre, ...configVarStyle}}>{this.props.value}</span> { /* eslint-disable-line */ }
+          <span className="config-span" style={{...GlobalStyles.CommitLink, ...GlobalStyles.CommitLinkPre, ...configVarStyle}}>{this.props.value}</span> { /* eslint-disable-line */ }
         </TableCell>
         <TableCell style={style.tableCell}>
           <div style={{ display: 'flex', justifyContent: 'flex-end' }}>

--- a/src/components/ConfigVars/index.jsx
+++ b/src/components/ConfigVars/index.jsx
@@ -38,12 +38,15 @@ const style = {
     },
   },
   refresh: {
+    tableCell: {
+      padding: '0px',
+    },
     div: {
-      marginLeft: 'auto',
-      marginRight: 'auto',
-      width: '40px',
-      height: '350px',
-      marginTop: '20%',
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      flexGrow: 1,
+      height: '450px',
     },
     indicator: {
       display: 'inline-block',
@@ -456,10 +459,10 @@ export default class ConfigVar extends BaseComponent {
               </Typography>
               <Paper style={{ marginBottom: '0.5rem', ...GlobalStyles.StandardPadding }}>
                 {this.state.proposeAdded.map(x => (
-                    <div key={"code-style-" + x} style={configVarStyle}> { /* eslint-disable-line */ }
-                      {x}={JSON.stringify(this.state.changes[x])}
-                    </div>
-                  ))}
+                  <div key={"code-style-" + x} style={configVarStyle}> { /* eslint-disable-line */ }
+                    {x}={JSON.stringify(this.state.changes[x])}
+                  </div>
+                ))}
               </Paper>
             </div>
           ) : ''}
@@ -470,10 +473,10 @@ export default class ConfigVar extends BaseComponent {
               </Typography>
               <Paper style={{ marginBottom: '0.5rem', ...GlobalStyles.StandardPadding }}>
                 {this.state.proposeRemoved.map(x => (
-                    <div key={"code-style-" + x} style={configVarStyle}> { /* eslint-disable-line */ }
-                      {x}={JSON.stringify(this.state.changes[x])}
-                    </div>
-                  ))}
+                  <div key={"code-style-" + x} style={configVarStyle}> { /* eslint-disable-line */ }
+                    {x}={JSON.stringify(this.state.changes[x])}
+                  </div>
+                ))}
               </Paper>
             </div>
           ) : ''}
@@ -484,10 +487,10 @@ export default class ConfigVar extends BaseComponent {
               </Typography>
               <Paper style={{ marginBottom: '0.5rem', ...GlobalStyles.StandardPadding }}>
                 {this.state.proposeUpdated.map(x => (
-                    <div key={"code-style-" + x} style={configVarStyle}> { /* eslint-disable-line */ }
-                      {x}={JSON.stringify(this.state.changes[x])}
-                    </div>
-                  ))}
+                  <div key={"code-style-" + x} style={configVarStyle}> { /* eslint-disable-line */ }
+                    {x}={JSON.stringify(this.state.changes[x])}
+                  </div>
+                ))}
               </Paper>
             </div>
           ) : ''}
@@ -498,10 +501,10 @@ export default class ConfigVar extends BaseComponent {
               </Typography>
               <Paper style={{ marginBottom: '0.5rem', ...GlobalStyles.StandardPadding }}>
                 {this.state.proposeMetadata.map(x => (
-                    <div key={"code-style-" + x} style={configVarStyle}> { /* eslint-disable-line */ }
-                      {x}
-                    </div>
-                  ))}
+                  <div key={"code-style-" + x} style={configVarStyle}> { /* eslint-disable-line */ }
+                    {x}
+                  </div>
+                ))}
               </Paper>
             </div>
           ) : ''}
@@ -628,22 +631,23 @@ export default class ConfigVar extends BaseComponent {
 
   renderLoading() { /* eslint-disable-line */
     return (
-      <div style={style.refresh.div}>
-        <CircularProgress
-          top={0}
-          size={40}
-          left={0}
-          style={style.refresh.indicator}
-          status="loading"
-        />
-      </div>
+      <TableRow>
+        <TableCell style={style.refresh.tableCell} colSpan={3}>
+          <div style={style.refresh.div}>
+            <CircularProgress
+              top={0}
+              size={40}
+              left={0}
+              style={style.refresh.indicator}
+              status="loading"
+            />
+          </div>
+        </TableCell>
+      </TableRow>
     );
   }
 
   render() {
-    if (this.state.loading) {
-      return this.renderLoading();
-    }
     return (
       <div>
         <Table className="config-list">
@@ -657,7 +661,10 @@ export default class ConfigVar extends BaseComponent {
             {this.renderHeader()}
           </TableHead>
           <TableBody>
-            {isEmpty(this.state.config) ? this.renderNoConfigVars() : this.renderConfigVars()}
+            {this.state.loading && this.renderLoading()}
+            {!this.state.loading && (
+              isEmpty(this.state.config) ? this.renderNoConfigVars() : this.renderConfigVars()
+            )}
           </TableBody>
         </Table>
         {this.renderEditConfigVarDialog()}

--- a/src/components/Formations/NewFormation.jsx
+++ b/src/components/Formations/NewFormation.jsx
@@ -221,7 +221,10 @@ export default class NewFormation extends BaseComponent {
         category: 'DYNOS',
         action: 'Created new formation',
       });
-      this.props.onComplete('New Formation Added', true);
+
+      // Add a pleasing amount of loading instead of flashing the indicator
+      // for a variable amount of time
+      setTimeout(() => this.props.onComplete('New Formation Added', true), 1000);
     } catch (error) {
       if (!this.isCancel(error)) {
         this.setState({

--- a/src/components/Releases/NewBuild.jsx
+++ b/src/components/Releases/NewBuild.jsx
@@ -9,10 +9,15 @@ import ConfirmationModal from '../ConfirmationModal';
 import BaseComponent from '../../BaseComponent';
 
 const style = {
-  stepper: {
+  root: {
     width: '100%',
     maxWidth: 700,
     margin: 'auto',
+    minHeight: 200,
+    paddingBottom: '12px',
+  },
+  stepper: {
+    height: 40,
   },
   buttons: {
     div: {
@@ -34,11 +39,10 @@ const style = {
   },
   refresh: {
     div: {
-      marginLeft: 'auto',
-      marginRight: 'auto',
-      width: '40px',
-      height: '50px',
-      paddingTop: '24px',
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      flexGrow: 1,
     },
     indicator: {
       display: 'inline-block',
@@ -67,6 +71,15 @@ const style = {
         margin: 'auto 0',
       },
     },
+  },
+  contentContainer: {
+    margin: '0 32px', height: '250px', display: 'flex', flexDirection: 'column',
+  },
+  stepContainer: {
+    flexGrow: 1, display: 'flex', flexDirection: 'column', justifyContent: 'center',
+  },
+  buttonContainer: {
+    paddingTop: '12px',
   },
 };
 
@@ -164,8 +177,8 @@ export default class NewBuild extends BaseComponent {
           errorText: null,
           url: '',
           displayUrl: {},
-          branch: null,
-          version: null,
+          branch: '',
+          version: '',
         });
       }
     }
@@ -262,40 +275,38 @@ export default class NewBuild extends BaseComponent {
             </div>
           </div>
         );
-      case 4:
-        return (
-          <div style={style.refresh.div}>
-            <CircularProgress top={0} size={40} left={0} style={style.refresh.indicator} status="loading" />
-          </div>
-        );
       default:
         return 'You\'re a long way from home sonny jim!';
     }
   }
 
   renderContent() {
-    const { stepIndex } = this.state;
-    const contentStyle = { margin: '0 32px', overflow: 'hidden' };
+    const { stepIndex, loading } = this.state;
     return (
-      <div style={contentStyle}>
-        <div>{this.renderStepContent(stepIndex)}</div>
+      <div style={style.contentContainer}>
+        {!loading ? (
+          <div style={style.stepContainer}>
+            {this.renderStepContent(stepIndex)}
+          </div>
+        ) : (
+          <div style={style.refresh.div}>
+            <CircularProgress top={0} size={40} left={0} status="loading" />
+          </div>
+        )}
         <div style={style.buttons.div}>
-          {stepIndex < 4 && (
-            <Button
-              className="back"
-              disabled={stepIndex === 0}
-              onClick={this.handlePrev}
-              style={style.buttons.back}
-            >Back</Button>
-          )}
-          {stepIndex < 4 && (
-            <Button
-              variant="contained"
-              className="next"
-              color="primary"
-              onClick={this.handleNext}
-            >{stepIndex === 3 ? 'Finish' : 'Next'}</Button>
-          )}
+          <Button
+            className="back"
+            disabled={stepIndex === 0}
+            onClick={this.handlePrev}
+            style={style.buttons.back}
+          >Back</Button>
+          <Button
+            variant="contained"
+            className="next"
+            color="primary"
+            onClick={this.handleNext}
+            disabled={loading}
+          >{stepIndex === 3 ? 'Finish' : 'Next'}</Button>
         </div>
       </div>
     );
@@ -306,8 +317,8 @@ export default class NewBuild extends BaseComponent {
       stepIndex, submitFail, submitMessage,
     } = this.state;
     return (
-      <div style={style.stepper}>
-        <Stepper activeStep={stepIndex}>
+      <div style={style.root}>
+        <Stepper style={style.stepper} activeStep={stepIndex}>
           <Step>
             <StepLabel>Url</StepLabel>
           </Step>

--- a/src/components/Releases/index.jsx
+++ b/src/components/Releases/index.jsx
@@ -73,11 +73,11 @@ const style = {
   },
   refresh: {
     div: {
-      marginLeft: 'auto',
-      marginRight: 'auto',
-      width: '40px',
-      height: '350px',
-      marginTop: '20%',
+      height: '450px',
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'center',
+      alignItems: 'center',
     },
     indicator: {
       display: 'inline-block',
@@ -183,6 +183,7 @@ export default class Releases extends BaseComponent {
       restrictedSpace: false,
       confirmRebuildOpen: false,
       rebuildRelease: null,
+      collapse: true,
     };
   }
 
@@ -300,11 +301,11 @@ export default class Releases extends BaseComponent {
   }
 
   handleNewBuild() {
-    this.setState({ new: true });
+    this.setState({ collapse: false, new: true });
   }
 
   handleNewBuildCancel() {
-    this.setState({ new: false });
+    this.setState({ collapse: true });
   }
 
   handleBuildLogs(release) {
@@ -313,14 +314,6 @@ export default class Releases extends BaseComponent {
       release,
       title: `Logs for v${release.id}`,
     });
-  }
-
-  handleNewRelease() {
-    this.setState({ new: true });
-  }
-
-  handleNewReleaseCancel() {
-    this.setState({ new: false });
   }
 
   handleSnackClose() {
@@ -341,6 +334,7 @@ export default class Releases extends BaseComponent {
       new: false,
       snackOpen: true,
       message,
+      collapse: true,
     });
     this.getReleases();
   }
@@ -350,6 +344,7 @@ export default class Releases extends BaseComponent {
       loading: true,
       new: false,
       snackOpen: false,
+      collapse: true,
     });
     this.getReleases();
   }
@@ -381,7 +376,7 @@ export default class Releases extends BaseComponent {
               <div style={style.release.info.root}>
                 {!release.release ? `Build ${release.status} - ` : `Deployed v${release.version} - `} {info1.join(' ')}
                 {release.source_blob && release.source_blob.version ? (
-                  <a style={{ textDecoration:'none', marginLeft: '0.5em' }} href={release.source_blob.version}>
+                  <a style={{ textDecoration: 'none', marginLeft: '0.5em' }} href={release.source_blob.version}>
                     <pre style={GlobalStyles.CommitLink}><code>#{release.source_blob.commit.substring(0, 7)}</code></pre> { /* eslint-disable-line */ }
                   </a>
                 ) : ''}&nbsp;<ReleaseStatus release={release} />
@@ -511,7 +506,6 @@ export default class Releases extends BaseComponent {
             disabled
             style={{ ...style.iconButton, opacity: 0.35 }}
             className="new-build"
-            onClick={() => { this.handleNewBuild(); }}
           >
             <AddIcon />
           </IconButton>
@@ -521,7 +515,12 @@ export default class Releases extends BaseComponent {
 
     return (
       <div>
-        <Collapse unmountOnExit mountOnEnter in={this.state.new}>
+        <Collapse
+          unmountOnExit
+          mountOnEnter
+          onExited={() => this.setState({ new: false })}
+          in={!this.state.collapse}
+        >
           <div style={style.collapse.container}>
             <div style={style.collapse.header.container}>
               <Typography style={style.collapse.header.title} variant="overline">{this.state.new && 'New Build'}</Typography>
@@ -544,7 +543,7 @@ export default class Releases extends BaseComponent {
         </Collapse>
         <div style={style.header.container}>
           <Typography style={style.header.title} variant="overline">Release</Typography>
-          {!this.state.new && (
+          {this.state.collapse && (
             <div style={style.header.actions.container}>
               <div style={style.header.actions.button}>
                 {newReleaseButton}

--- a/src/components/Search.jsx
+++ b/src/components/Search.jsx
@@ -64,6 +64,9 @@ const Control = props => (
       },
     }}
     autoFocus={props.selectProps.autoFocus}
+    InputLabelProps={{
+      shrink: !!props.selectProps.textFieldProps.label,
+    }}
     {...props.selectProps.textFieldProps}
   />
 );
@@ -138,7 +141,10 @@ const components = {
 
 class Search extends PureComponent {
   render() {
-    const { onChange, value, classes, theme, placeholder, options, error, autoFocus } = this.props;
+    const {
+      onChange, value, classes, theme, placeholder,
+      options, error, autoFocus, label, helperText,
+    } = this.props;
 
     const selectStyles = {
       input: base => ({
@@ -154,7 +160,7 @@ class Search extends PureComponent {
       <div className={classes.root}>
         <NoSsr>
           <SelectComponent
-            textFieldProps={{ error }}
+            textFieldProps={{ error, label, helperText }}
             classes={classes}
             styles={selectStyles}
             options={options}
@@ -199,11 +205,15 @@ Search.propTypes = {
   theme: PropTypes.object.isRequired,
   error: PropTypes.bool,
   autoFocus: PropTypes.bool,
+  label: PropTypes.string,
+  helperText: PropTypes.string,
 };
 
 Search.defaultProps = {
   error: false,
   autoFocus: false,
+  label: null,
+  helperText: '',
 }
 /* eslint-enable */
 

--- a/src/components/Webhooks/NewWebhook.jsx
+++ b/src/components/Webhooks/NewWebhook.jsx
@@ -204,7 +204,10 @@ export default class NewWebhook extends BaseComponent {
         category: 'WEBHOOK',
         action: 'Created new webhook',
       });
-      this.props.onComplete('Webhook Created');
+
+      // Add a pleasing amount of loading instead of flashing the indicator
+      // for a variable amount of time
+      setTimeout(() => this.props.onComplete('Webhook Created', true), 1000);
     } catch (error) {
       if (!this.isCancel(error)) {
         this.setState({

--- a/src/components/Webhooks/index.jsx
+++ b/src/components/Webhooks/index.jsx
@@ -15,11 +15,11 @@ import BaseComponent from '../../BaseComponent';
 const style = {
   refresh: {
     div: {
-      marginLeft: 'auto',
-      marginRight: 'auto',
-      width: '40px',
-      height: '350px',
-      marginTop: '20%',
+      height: '450px',
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'center',
+      alignItems: 'center',
     },
     indicator: {
       display: 'inline-block',
@@ -65,6 +65,7 @@ export default class Webhooks extends BaseComponent {
       submitFail: false,
       submitMessage: '',
       events: [],
+      collapse: true,
     };
   }
 
@@ -95,11 +96,11 @@ export default class Webhooks extends BaseComponent {
   }
 
   handleNewWebhook = () => {
-    this.setState({ new: true });
+    this.setState({ new: true, collapse: false });
   }
 
   handleNewWebhookCancel = () => {
-    this.setState({ new: false });
+    this.setState({ collapse: true });
   }
 
   handleRequestClose = () => {
@@ -121,6 +122,7 @@ export default class Webhooks extends BaseComponent {
         message,
         open: true,
         confirmWebhookOpen: false,
+        collapse: true,
       });
     } catch (err) {
       if (!this.isCancel(err)) {
@@ -149,13 +151,18 @@ export default class Webhooks extends BaseComponent {
   render() {
     return (
       <div>
-        <Collapse unmountOnExit mountOnEnter in={this.state.new}>
+        <Collapse
+          unmountOnExit
+          mountOnEnter
+          onExited={() => this.setState({ new: false })}
+          in={!this.state.collapse}
+        >
           <div style={style.collapse.container}>
             <div style={style.collapse.header.container}>
               <Typography style={style.collapse.header.title} variant="overline">{this.state.new && 'New Webhook'}</Typography>
               {this.state.new && <IconButton className="webhook-cancel" onClick={this.handleNewWebhookCancel}><RemoveIcon /></IconButton>}
             </div>
-            <NewWebhook app={this.props.app} onComplete={this.reload} />
+            {this.state.new && <NewWebhook app={this.props.app} onComplete={this.reload} />}
           </div>
         </Collapse>
         <div style={{ height: '52px', display: 'flex', padding: '4px 24px', borderBottom: '1px solid rgba(224, 224, 224, 1)', alignItems: 'center', color: 'rgba(0, 0, 0, 0.87)' }}>
@@ -168,7 +175,7 @@ export default class Webhooks extends BaseComponent {
             </div>
           </div>
           <div style={{ width: '50px' }}>
-            {!this.state.new && (
+            {this.state.collapse && (
               <Tooltip placement="bottom-end" title="New Webhook">
                 <IconButton className="new-webhook" onClick={this.handleNewWebhook}>
                   <AddIcon />
@@ -177,21 +184,19 @@ export default class Webhooks extends BaseComponent {
             )}
           </div>
         </div>
-        <div>
-          {this.state.loading ? (
-            <div style={style.refresh.div}>
-              <CircularProgress top={0} size={40} left={0} style={style.refresh.indicator} status="loading" />
-            </div>
-          ) : (
-            <div>
-              {(this.state.webhooks && this.state.webhooks.length) > 0 ? (
-                <div className="webhook-list">{this.renderWebhooks()}</div>
-              ) : (
-                <Typography variant="body2" className="no-results" style={style.noResults}>No Webhooks</Typography>
-              )}
-            </div>
-          )}
-        </div>
+        {this.state.loading ? (
+          <div style={style.refresh.div}>
+            <CircularProgress top={0} size={40} left={0} style={style.refresh.indicator} status="loading" />
+          </div>
+        ) : (
+          <div>
+            {(this.state.webhooks && this.state.webhooks.length) > 0 ? (
+              <div className="webhook-list">{this.renderWebhooks()}</div>
+            ) : (
+              <Typography variant="body2" className="no-results" style={style.noResults}>No Webhooks</Typography>
+            )}
+          </div>
+        )}
         <ConfirmationModal
           open={this.state.submitFail}
           onOk={this.handleDialogClose}

--- a/src/config/GlobalStyles.jsx
+++ b/src/config/GlobalStyles.jsx
@@ -102,7 +102,7 @@ const GlobalStyles = {
     borderRadius: '3px',
   },
   CommitLink: {
-    display:'inline',
+    display: 'inline',
     color: '#475366',
     backgroundColor: softBackground,
     padding: '2.5px 5px 3px 5px',
@@ -143,19 +143,20 @@ GlobalStyles.FormSubHeaderStyle = {
 };
 
 GlobalStyles.ConfigVarStyle = {
-  ...GlobalStyles.CommitLink, 
+  ...GlobalStyles.CommitLink,
   ...GlobalStyles.CommitLinkPre,
-  fontFamily:'courier',
-  padding:'7.5px 10px', 
-  boxSizing:'border-box',
-  width:'100%',
-  /*overflow:'hidden', 
+  fontFamily: 'courier',
+  padding: '7.5px 10px',
+  boxSizing: 'border-box',
+  width: '100%',
+  /* overflow:'hidden',
   textOverflow:'ellipsis',
-  whiteSpace:'nowrap',*/
-  whiteSpace:'pre',
-  overflow:'scroll',
-  display:'inline-block',
-  height:'2.25rem',
+  whiteSpace:'nowrap', */
+  whiteSpace: 'pre',
+  overflowX: 'auto',
+  scrollbarWidth: 'thin',
+  display: 'inline-block',
+  height: '2.4rem',
 };
 
 export default GlobalStyles;

--- a/src/config/GlobalTheme.jsx
+++ b/src/config/GlobalTheme.jsx
@@ -50,7 +50,7 @@ const GlobalTheme = createMuiTheme({
   overrides: {
     MuiStepper: {
       root: {
-        padding: '24px 0px',
+        padding: '12px 0px',
       },
     },
     MuiToolbar: { // Used in the main Scenes for their toolbar above the table (apps, orgs, etc)

--- a/test/e2e/apps.test.js
+++ b/test/e2e/apps.test.js
@@ -863,6 +863,7 @@ test // eslint-disable-line no-undef
       .click('button.attach-addon')
       .typeText('.app-search input', `${appName2}-testcafe`)
       .pressKey('enter')
+      .click('button.next')
       .click('.addon-menu')
       .click('.akkeris-postgresql')
       .click('button.next')

--- a/test/e2e/apps.test.js
+++ b/test/e2e/apps.test.js
@@ -396,7 +396,9 @@ test('Should be able to toggle into maintenance mode', async (t) => { // eslint-
     .typeText('.new-type input', 'web')
     .click('button.next')
     .click('button.next') // quantity (1)
-    .click('button.next') // size (gp1)
+    .typeText(Selector('.select-textfield'), 'gp1')
+    .pressKey('enter')
+    .click('button.next')
     .typeText('.new-port input', '8000', { replace: true })
     .click('button.next')
     .click('button.next') // summary
@@ -478,7 +480,8 @@ test('Should be able to create edit and delete formations', async (t) => { // es
     // Check step 2 caption
     .expect(Selector('.step-1-label .step-label-caption').innerText)
     .contains('2')
-    .click('.new-size .gp2')
+    .typeText(Selector('.select-textfield'), 'gp2')
+    .pressKey('enter')
     .click('button.next')
 
     // Check step 3 caption
@@ -503,6 +506,8 @@ test('Should be able to create edit and delete formations', async (t) => { // es
     .typeText('.new-type input', 'web')
     .click('button.next')
     .click('button.next')
+    .typeText(Selector('.select-textfield'), 'gp1')
+    .pressKey('enter')
     .click('button.next')
     .click('button.next')
     .click('button.next')

--- a/test/e2e/apps.test.js
+++ b/test/e2e/apps.test.js
@@ -834,6 +834,7 @@ test // eslint-disable-line no-undef
       .click('button.attach-addon')
       .typeText('.app-search input', `${appName2}-testcafe`)
       .pressKey('enter')
+      .click('button.next')
       .expect(Selector('.step-0-label .step-label-caption').exists)
       .ok()
       .click('.addon-menu')

--- a/test/e2e/pipelines.test.js
+++ b/test/e2e/pipelines.test.js
@@ -143,7 +143,9 @@ fixture('Pipeline Info Page') // eslint-disable-line no-undef
       .typeText('.new-type input', 'web')
       .click('button.next')
       .click('button.next') // quantity (1)
-      .click('button.next') // size (gp1)
+      .typeText(Selector('.select-textfield'), 'gp1')
+      .pressKey('enter')
+      .click('button.next')
       .typeText('.new-port input', '8080', { replace: true })
       .click('button.next')
       .click('button.next') // summary
@@ -166,7 +168,7 @@ fixture('Pipeline Info Page') // eslint-disable-line no-undef
       .wait(10000)
 
 
-      .navigateTo(`${baseUrl}/apps`)   
+      .navigateTo(`${baseUrl}/apps`)
       .click('button.addFilter')
       .typeText(Selector('.filter-select-input input'), 'testcafe')
       .click('.filter-select-results .testcafe')
@@ -235,7 +237,9 @@ fixture('Pipeline Info Page') // eslint-disable-line no-undef
       .typeText('.new-type input', 'web')
       .click('button.next')
       .click('button.next') // quantity (1)
-      .click('button.next') // size (gp1)
+      .typeText(Selector('.select-textfield'), 'gp1')
+      .pressKey('enter')
+      .click('button.next')
       .typeText('.new-port input', '8080', { replace: true })
       .click('button.next')
       .click('button.next') // summary

--- a/webpack-dev-server.config.js
+++ b/webpack-dev-server.config.js
@@ -37,6 +37,10 @@ const config = {
           cacheDirectory: true,
         },
       },
+      {
+        test: /.css$/i,
+        use: ['style-loader', 'css-loader'],
+      },
     ],
   },
   externals: {

--- a/webpack-production.config.js
+++ b/webpack-production.config.js
@@ -43,6 +43,10 @@ const config = {
           cacheDirectory: true,
         },
       },
+      {
+        test: /.css$/i,
+        use: ['style-loader', 'css-loader'],
+      },
     ],
   },
 };


### PR DESCRIPTION
- Made the behavior and appearance of app tabs more consistent
  - Set the initial loading indicator div height to look the same across all tabs
  - "Add New" components behind Collapse elements now mount and unmount consistently
  - Stepper content height is now constant for individual components (instead of jumping around each time a new step is loaded)
  - Stepper buttons always present, and disabled when not available (instead of appearing and disappearing inconsistently)
  - Other misc improvements
    - webhook checkbox columns improved
    - dyno size selector on new dyno stepper searchable instead of big list of radio buttons
- Improved scrollbar styling on ConfigVar page
  - On Webkit compatible browsers (Chrome, Safari, Edge) a custom scrollbar style is used that is unobtrusive
    - Had to add support for importing CSS stylesheets. This will help us in the future when we (hopefully) move away from inline styles
  - On Firefox (non-webkit), the "scrollbar-width: thin" proposal is used
    - https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-width
    - Might have to revisit this in the future if it's taken out in a future version of Firefox
