### PR TITLE
Fast App Loading

### DIFF
--- a/src/components/Addons/AttachAddon.jsx
+++ b/src/components/Addons/AttachAddon.jsx
@@ -89,7 +89,7 @@ export default class AttachAddon extends BaseComponent {
   getApps = async () => {
     const { app } = this.props;
     try {
-      const { data: apps } = await this.api.getApps();
+      const { data: apps } = await this.api.getApps('?simple=true');
       // Remove the current app from the results
       apps.splice(apps.findIndex(i => i.name.toLowerCase() === app.toLowerCase()), 1);
       this.setState({ apps, loading: false });

--- a/src/components/GlobalSearch.jsx
+++ b/src/components/GlobalSearch.jsx
@@ -221,7 +221,7 @@ class GlobalSearch extends BaseComponent {
 
   getOptions = async () => {
     try {
-      const { data: apps } = await this.api.getApps();
+      const { data: apps } = await this.api.getApps('?simple=true');
       const { data: pipelines } = await this.api.getPipelines();
       const { data: sites } = await this.api.getSites();
 

--- a/src/components/Pipelines/CreateOrUpdatePipelineCoupling.jsx
+++ b/src/components/Pipelines/CreateOrUpdatePipelineCoupling.jsx
@@ -82,7 +82,7 @@ export default class CreateOrUpdatePipelineCoupling extends BaseComponent {
         ...deepCopy(originalState),
         selected: this.props.coupling ? this.props.coupling.required_status_checks.contexts : [],
       });
-      const { data: apps } = await this.api.getApps();
+      const { data: apps } = await this.api.getApps('?simple=true');
       const {
         data: statuses,
       } = await this.api.getAvailablePipelineStatuses(this.props.pipeline.name);

--- a/src/components/Sites/NewRoute.jsx
+++ b/src/components/Sites/NewRoute.jsx
@@ -73,7 +73,7 @@ export default class NewRoute extends BaseComponent {
 
   getApps = async () => {
     try {
-      const { data: apps } = await this.api.getApps();
+      const { data: apps } = await this.api.getApps('?simple=true');
       apps.forEach((i) => { i.value = i.id; i.label = i.name; }); // eslint-disable-line
       this.setState({ apps, app: apps[0], loading: false });
     } catch (err) {

--- a/src/scenes/Apps/Apps.jsx
+++ b/src/scenes/Apps/Apps.jsx
@@ -92,7 +92,7 @@ export default class Apps extends BaseComponent {
     try {
       const { data: spaces } = await this.api.getSpaces();
       const { data: regions } = await this.api.getRegions();
-      let { data: apps } = await this.api.getApps();
+      let { data: apps } = await this.api.getApps('?simple=true');
       const { data: favorites } = await this.api.getFavorites();
       apps = apps.map(app => ({
         ...app,

--- a/src/services/api/index.js
+++ b/src/services/api/index.js
@@ -33,8 +33,8 @@ function isCancel(error) {
 // unless the function is bound to an object that has this.cancelToken set
 // before it is invoked.
 
-function getApps() {
-  return axios.get('/api/apps', { cancelToken: this.cancelToken });
+function getApps(paramstring) {
+  return axios.get(paramstring ? `/api/apps${paramstring}` : '/api/apps', { cancelToken: this.cancelToken });
 }
 
 function getApp(app) {


### PR DESCRIPTION
Where possible, use the `simple=true` URL query param for fast app loading. This greatly increases the speed of the main app list page and the global search feature.

**NOTE**: This requires functionality available in v1.4 of the controller-api (namely the ability to specify this query param). The UI will be updated to v1.4 alongside the controller to indicate that the controller needs to be on this version for the UI update to function properly.